### PR TITLE
Always recreate views when migrating

### DIFF
--- a/lib/sequel/plugins/inline_migrations.rb
+++ b/lib/sequel/plugins/inline_migrations.rb
@@ -221,7 +221,7 @@ module Sequel::Plugins::InlineMigrations
 			migrator = self.migrator( target )
 			classes_to_install = self.uninstalled_tables
 			self.db.log_info "Classes with tables that need to be installed: %p" % [ classes_to_install ]
-			views_to_install = self.uninstalled_views
+			views_to_install = self.installed_views + self.uninstalled_views
 			self.db.log_info "Views to install: %p" % [ views_to_install.map(&:table_name) ]
 
 			self.db.transaction do
@@ -234,7 +234,7 @@ module Sequel::Plugins::InlineMigrations
 				self.after_migration
 
 				self.db.log_info "(Re)-creating any modeled views..."
-				views_to_install.each( &:create_view )
+				views_to_install.each( &:create_view! )
 			end
 		end
 

--- a/lib/sequel/plugins/inline_schema.rb
+++ b/lib/sequel/plugins/inline_schema.rb
@@ -362,6 +362,13 @@ module Sequel::Plugins::InlineSchema
 		end
 
 
+		### Return an Array of model classes whose views exist, in the order they need to be
+		### created.
+		def installed_views
+			return self.tsort.find_all( &:is_view_class? ).select( &:table_exists? )
+		end
+
+
 		### Returns +true+ if the receiver is defined via a view rather than a table.
 		def is_view_class?
 			return self.respond_to?( :view_dataset ) && self.view_dataset ? true : false


### PR DESCRIPTION
Hello @ged ! So we have an issue where a materialized view added a column after it was initially created, but because it already was "installed" that column is never added during a migration since `migrate` only takes action on uninstalled views.  To fix this we were thinking of doing something like this pr to always recreate a view during a migration so that any changes since the last migration take effect.

The problem with this though right now is that we have an installed view that is not being found when calling `create_view!`, and it seems to be filtered out by this last line here in `view_exists?` and I'm not really sure that that line is doing? https://github.com/ged/sequel-inlineschema/blob/master/lib/sequel/plugins/inline_schema.rb#L271

Thanks for any info on this one!